### PR TITLE
Improve visibility for reload implementation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,6 @@ class syslog_ng (
     group  => $group,
     warn   => true,
     ensure_newline => true,
-    notify =>  Exec['syslog_ng_reload'],
   }
 
   notice("tmp_config_file: ${tmp_config_file}")

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -6,27 +6,36 @@ class syslog_ng::reload (
 
   $config_file     = $::syslog_ng::config_file
   $tmp_config_file = $::syslog_ng::params::tmp_config_file
-
+  $exec_path = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:'
 
   $syslog_ng_ctl_full_path = "${::syslog_ng::sbin_path}/syslog-ng-ctl"
   $syslog_ng_full_path = "${::syslog_ng::sbin_path}/syslog-ng"
 
-  # echo always returns 0
-  $check_syntax_command = $syntax_check_before_reloads ? {
-    true  => "${syslog_ng_full_path} --syntax-only --cfgfile ${tmp_config_file}",
-    false => 'echo'
+  exec { 'syslog_ng_syntax_check':
+    command     => "${syslog_ng_full_path} --syntax-only --cfgfile ${tmp_config_file}",
+    path        => $exec_path,
+    refreshonly => true
   }
 
   notice("syslog_ng::reload: syntax_check_before_reloads=${syntax_check_before_reloads}")
-  notice("syslog_ng::reload: check_syntax_command=${check_syntax_command}")
 
   exec { 'syslog_ng_reload':
     command     => "${syslog_ng_ctl_full_path} reload",
-    path        => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:',
+    path        => $exec_path,
     refreshonly => true,
     try_sleep   => 1,
     logoutput   => true,
-    onlyif      => $check_syntax_command,
-    refresh     => "cp ${tmp_config_file} ${config_file}"
+  }
+  
+  exec { 'syslog_ng_deploy_config':
+    command     => "cp ${tmp_config_file} ${config_file}",
+    path        => $exec_path,
+    refreshonly => true
+  }
+
+  if $syntax_check_before_reloads {
+    File[$tmp_config_file] ~> Exec['syslog_ng_syntax_check'] ~> Exec['syslog_ng_deploy_config'] ~> Exec['syslog_ng_reload']
+  } else {
+    File[$tmp_config_file] ~>                                   Exec['syslog_ng_deploy_config'] ~> Exec['syslog_ng_reload']
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -33,4 +33,23 @@ describe 'syslog_ng' do
       should contain_syslog_ng__module('baz')
     }
   end
+  context 'When asked to check syntax before reload' do
+    let(:params) {{
+      :syntax_check_before_reloads => true
+    }}
+    it {
+      should contain_file('/tmp/syslog-ng.conf.tmp').that_notifies('Exec[syslog_ng_syntax_check]')
+      should contain_exec('syslog_ng_syntax_check').that_notifies('Exec[syslog_ng_deploy_config]')
+      should contain_exec('syslog_ng_deploy_config').that_notifies('Exec[syslog_ng_reload]')
+    }
+  end
+  context 'When asked not to check syntax before reload' do
+    let(:params) {{
+      :syntax_check_before_reloads => false
+    }}
+    it {
+      should contain_file('/tmp/syslog-ng.conf.tmp').that_notifies('Exec[syslog_ng_deploy_config]')
+      should contain_exec('syslog_ng_deploy_config').that_notifies('Exec[syslog_ng_reload]')
+    }
+  end
 end


### PR DESCRIPTION
This should make troubleshooting easier, and improve code readability (yes, I hate `onlyif` :))

replace `onlyif` by a dependant Exec to have more puppet output
 When using 'onlyif' parameter in Exec resource, we don't see any output
replace `refresh` by another Exec to see output when problems copying
 the file
