### PR TITLE
travis: disable the 1.8.7 Ruby builds, because they are not working well...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.2
 script: "rake spec"
 env:


### PR DESCRIPTION
... with Travis

I will find some other Ruby versions which work well.
