### PR TITLE
Prepend concat::fragment titles with class name and type

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@ define syslog_ng::config (
   $content = '',
   $order = '5'
 ) {
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::config ${title}":
     target  => $::syslog_ng::tmp_config_file,
     content => "${content}\n",
     order => $order

--- a/manifests/destination.pp
+++ b/manifests/destination.pp
@@ -5,7 +5,7 @@ define syslog_ng::destination (
   $id = $title
   $order = '70'
     
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::destination ${title}":
     target  => $::syslog_ng::tmp_config_file,
     content => generate_statement($id, $type, $params),
     order => $order

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -5,7 +5,7 @@ define syslog_ng::filter (
   $id = $title
   $order = '50'
 
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::filter ${title}":
     target  => $::syslog_ng::tmp_config_file,
     content => generate_statement($id, $type, $params),
     order => $order

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class syslog_ng (
 
   notice("tmp_config_file: ${tmp_config_file}")
 
-  concat::fragment {'header':
+  concat::fragment {'syslog_ng header':
     target => $tmp_config_file,
     content => $config_file_header,
     order => '01'

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -2,7 +2,7 @@ define syslog_ng::log (
   $params = []
 ) {
   $order = '80'
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::log ${title}":
     target  => $::syslog_ng::tmp_config_file,
     content => generate_log($params),
     order => $order

--- a/manifests/options.pp
+++ b/manifests/options.pp
@@ -3,7 +3,7 @@ define syslog_ng::options (
 ) {
   $order = '10'
 
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::options ${title}":
     target  => $::syslog_ng::tmp_config_file,
     content => generate_options($options),
     order => $order

--- a/manifests/parser.pp
+++ b/manifests/parser.pp
@@ -5,7 +5,7 @@ define syslog_ng::parser (
   $id = $title
   $order = '40'
     
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::parser ${title}":
     target  => $::syslog_ng::tmp_config_file,
     content => generate_statement($id, $type, $params),
     order => $order

--- a/manifests/rewrite.pp
+++ b/manifests/rewrite.pp
@@ -5,7 +5,7 @@ define syslog_ng::rewrite (
   $id = $title
   $order = '30'
     
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::rewrite ${title}":
     target  => $::syslog_ng::tmp_config_file,
     content => generate_statement($id, $type, $params),
     order => $order

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -7,7 +7,7 @@ define syslog_ng::source (
   $id = $title
   $order = '60'
     
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::source ${title}":
     target  => $::syslog_ng::tmp_config_file,
       content => generate_statement($id, $type, $params),
       order => $order

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -5,7 +5,7 @@ define syslog_ng::template (
   $id = $title
   $order = '20'
     
-  concat::fragment { $title:
+  concat::fragment { "syslog_ng::template ${title}":
     target  => $::syslog_ng::tmp_config_file,
     content => generate_statement($id, $type, $params),
     order => $order

--- a/spec/defines/statement.rb
+++ b/spec/defines/statement.rb
@@ -10,6 +10,6 @@ shared_examples_for "Statement" do |id, type|
     let(:options) {{}} 
          
     it do 
-        should contain_concat__fragment(title)
+        should contain_concat__fragment("syslog_ng::"+type+" "+title)
     end
 end


### PR DESCRIPTION
This fixes duplicate declaration issues when using in conjunction with
other modules also using concat fragments