### PR TITLE
Various puppet-lint fixes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,5 @@
 define syslog_ng::config (
-  $content = '',
+  $content = undef,
   $order = '5'
 ) {
   concat::fragment { "syslog_ng::config ${title}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@ class syslog_ng (
   validate_array($modules)
   validate_hash($init_config_hash)
 
-  class {'syslog_ng::reload':
+  class {'::syslog_ng::reload':
     syntax_check_before_reloads => $syntax_check_before_reloads
   }
 

--- a/manifests/reload.pp
+++ b/manifests/reload.pp
@@ -2,7 +2,7 @@ class syslog_ng::reload (
   $syntax_check_before_reloads = true
 ) {
 
-  include syslog_ng::params
+  include ::syslog_ng::params
 
   $config_file     = $::syslog_ng::config_file
   $tmp_config_file = $::syslog_ng::params::tmp_config_file

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -1,7 +1,7 @@
 define syslog_ng::source (
   $params = []
 ) {
-  include syslog_ng::params
+  include ::syslog_ng::params
 
   $type = 'source'
   $id = $title

--- a/tests/config.pp
+++ b/tests/config.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::config {'version':
     content => '@version: 3.6',

--- a/tests/default_config.pp
+++ b/tests/default_config.pp
@@ -1,6 +1,6 @@
 class syslog_ng::default_config {
 
-    syslog_ng::config {"header comment":
+    syslog_ng::config {'header comment':
         content => '
     # Default syslog-ng.conf file which collects all local logs into a
     # single file called /var/log/messages.
@@ -38,7 +38,7 @@ class syslog_ng::default_config {
             {
                 'type' => 'file',
                 'options' => [
-                    "/var/log/messages"
+                    '/var/log/messages'
                 ]
             }
     }

--- a/tests/destination.pp
+++ b/tests/destination.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::destination { 'd_udp':
     params => {

--- a/tests/filter.pp
+++ b/tests/filter.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::filter {'f_tag_filter':
     params => {

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -10,4 +10,4 @@
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
 
-class  { 'syslog_ng': }
+class  { '::syslog_ng': }

--- a/tests/init_2.pp
+++ b/tests/init_2.pp
@@ -10,7 +10,7 @@
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
 
-class  { 'syslog_ng': 
-    tmp_config_file => '/tmp/syslog_ng_conf,
+class  { '::syslog_ng': 
+    tmp_config_file => '/tmp/syslog_ng_conf',
     package_name => 'syslog-ng'
 }

--- a/tests/log.pp
+++ b/tests/log.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::log {'l':
     params => [

--- a/tests/log_02.pp
+++ b/tests/log_02.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::log {'l2':
     params => [

--- a/tests/options.pp
+++ b/tests/options.pp
@@ -1,6 +1,6 @@
-include syslog_ng
+include ::syslog_ng
 
-syslog_ng::options { "global_options":
+syslog_ng::options { 'global_options':
     options => {
         'bad_hostname' => "'no'",
         'time_reopen'  => 10

--- a/tests/parser.pp
+++ b/tests/parser.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::parser {'p_hostname_segmentation':
     params => {

--- a/tests/rewrite.pp
+++ b/tests/rewrite.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::rewrite{'r_rewrite_subst':
     params => {

--- a/tests/site.pp
+++ b/tests/site.pp
@@ -9,19 +9,19 @@ syslog_ng::config {'version':
 }
 
 syslog_ng::options { 'global_options':
-	options => {
-		'bad_hostname' => "'no'"
-	}
+    options => {
+        'bad_hostname' => "'no'"
+    }
 }
 
 syslog_ng::source { 's_gsoc':
-	params => {
-	    'type' => 'tcp',
-	    'options' => {
-	    	'ip' => "'127.0.0.1'",
-	    	'port' => 1999
-	    }
-	}
+    params => {
+        'type' => 'tcp',
+        'options' => {
+            'ip' => "'127.0.0.1'",
+            'port' => 1999
+        }
+    }
 }
 
 syslog_ng::source {'s_external':

--- a/tests/site.pp
+++ b/tests/site.pp
@@ -1,6 +1,6 @@
 #import 'nodes.pp'
 
-include syslog_ng
+include ::syslog_ng
 
 # the header written by this module has order == 1, so the version must be 02
 syslog_ng::config {'version':

--- a/tests/source.pp
+++ b/tests/source.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::source { 's_gsoc':
     params => {

--- a/tests/template.pp
+++ b/tests/template.pp
@@ -1,4 +1,4 @@
-include syslog_ng
+include ::syslog_ng
 
 syslog_ng::template {'t_demo_filetemplate':
     params => [


### PR DESCRIPTION
These two commits fix various warnings reported by puppet-lint.

A lot more warnings were reported, but I did not fix them yet. For example:
* Wrong indentation in resource / class definitions
* Two-space soft tabs
* Undocumented defines
* Trailing whitespace

The indentation thing was the biggest complaint. Puppet-lint wants resources/classes to be called like this:

    class { '::foo':
        param           => 'somevalue',
        long_param_name => 'somevalue',
    }

In case the formatting gets messed up, the arrows are supposed to be aligned on top of each either.

If you want, I can fix most of the remaining warnings too and send another pull request.

Best regards,

Samuli